### PR TITLE
feat: add basic event sourcing infrastructure

### DIFF
--- a/MichelStore.Application/UseCases/Products/Create/Handler.cs
+++ b/MichelStore.Application/UseCases/Products/Create/Handler.cs
@@ -6,17 +6,19 @@ using MichelStore.Domain.Repositories;
 
 namespace MichelStore.Application.UseCases.Products.Create;
 
-public class Handler(IProductRepository repository, IUnitOfWork unitOfWork) : IRequestHandler<Command, Result<Response>>
+public class Handler(IProductRepository repository, IUnitOfWork unitOfWork, IEventStore eventStore) : IRequestHandler<Command, Result<Response>>
 {
     public async Task<Result<Response>> Handle(Command request, CancellationToken cancellationToken)
     {
-        var product = new Product
-        {
-            Title = request.Title
-        };
+        var product = Product.Create(request.Title);
 
         await repository.CreateAsync(product, cancellationToken);
         await unitOfWork.CommitAsync();
+
+        foreach (var domainEvent in product.DomainEvents)
+            await eventStore.AppendAsync(domainEvent, cancellationToken);
+
+        product.ClearDomainEvents();
 
         return Result.Success(new Response("Produto criado com sucesso"));
     }

--- a/MichelStore.Domain/Abstractions/AggregateRoot.cs
+++ b/MichelStore.Domain/Abstractions/AggregateRoot.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using MichelStore.Domain.Abstractions.Interfaces;
+
+namespace MichelStore.Domain.Abstractions;
+
+public abstract class AggregateRoot : Entity, IAggregateRoot
+{
+    private readonly List<IDomainEvent> _domainEvents = new();
+
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    protected void AddDomainEvent(IDomainEvent domainEvent)
+        => _domainEvents.Add(domainEvent);
+
+    public void ClearDomainEvents()
+        => _domainEvents.Clear();
+}

--- a/MichelStore.Domain/Abstractions/Interfaces/IDomainEvent.cs
+++ b/MichelStore.Domain/Abstractions/Interfaces/IDomainEvent.cs
@@ -1,0 +1,7 @@
+namespace MichelStore.Domain.Abstractions.Interfaces;
+
+public interface IDomainEvent
+{
+    Guid Id { get; }
+    DateTime OccurredOn { get; }
+}

--- a/MichelStore.Domain/Abstractions/Interfaces/IEventStore.cs
+++ b/MichelStore.Domain/Abstractions/Interfaces/IEventStore.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MichelStore.Domain.Abstractions.Interfaces;
+
+public interface IEventStore
+{
+    Task AppendAsync(IDomainEvent domainEvent, CancellationToken cancellationToken = default);
+}

--- a/MichelStore.Domain/Entities/Product.cs
+++ b/MichelStore.Domain/Entities/Product.cs
@@ -1,10 +1,24 @@
 using MichelStore.Domain.Abstractions;
-using MichelStore.Domain.Abstractions.Interfaces;
+using MichelStore.Domain.Events.ProductEvents;
 
 namespace MichelStore.Domain.Entities;
 
-public class Product : Entity, IAggregateRoot
+public class Product : AggregateRoot
 {
-    public string Title { get; set; } = string.Empty;
-    public bool IsActive { get; set; }
+    public string Title { get; private set; } = string.Empty;
+    public bool IsActive { get; private set; }
+
+    private Product() { }
+
+    public static Product Create(string title)
+    {
+        var product = new Product
+        {
+            Title = title
+        };
+
+        product.AddDomainEvent(new ProductCreated(product.Id, title));
+
+        return product;
+    }
 }

--- a/MichelStore.Domain/Events/ProductEvents/ProductCreated.cs
+++ b/MichelStore.Domain/Events/ProductEvents/ProductCreated.cs
@@ -1,0 +1,10 @@
+using System;
+using MichelStore.Domain.Abstractions.Interfaces;
+
+namespace MichelStore.Domain.Events.ProductEvents;
+
+public record ProductCreated(Guid ProductId, string Title) : IDomainEvent
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public DateTime OccurredOn { get; init; } = DateTime.UtcNow;
+}

--- a/MichelStore.Infrastructure/Data/AppDbContext.cs
+++ b/MichelStore.Infrastructure/Data/AppDbContext.cs
@@ -6,6 +6,7 @@ namespace MichelStore.Infrastructure.Data;
 public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
 {
     public DbSet<Product> Products { get; set; } = null!;
+    public DbSet<StoredEvent> StoredEvents { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
         =>

--- a/MichelStore.Infrastructure/Data/StoredEvent.cs
+++ b/MichelStore.Infrastructure/Data/StoredEvent.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace MichelStore.Infrastructure.Data;
+
+public class StoredEvent
+{
+    public Guid Id { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string Data { get; set; } = string.Empty;
+    public DateTime OccurredOn { get; set; }
+}

--- a/MichelStore.Infrastructure/DependencyInjection.cs
+++ b/MichelStore.Infrastructure/DependencyInjection.cs
@@ -12,6 +12,7 @@ public static class DependencyInjection
     {
         services.AddTransient<IUnitOfWork, UnitOfWork>();
         services.AddTransient<IProductRepository, ProductRepository>();
+        services.AddTransient<IEventStore, EventStore>();
 
         return services;
     }

--- a/MichelStore.Infrastructure/Repositories/EventStore.cs
+++ b/MichelStore.Infrastructure/Repositories/EventStore.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MichelStore.Domain.Abstractions.Interfaces;
+using MichelStore.Infrastructure.Data;
+
+namespace MichelStore.Infrastructure.Repositories;
+
+public class EventStore(AppDbContext context) : IEventStore
+{
+    public async Task AppendAsync(IDomainEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        var storedEvent = new StoredEvent
+        {
+            Id = domainEvent.Id,
+            Type = domainEvent.GetType().Name,
+            Data = JsonSerializer.Serialize(domainEvent),
+            OccurredOn = domainEvent.OccurredOn
+        };
+
+        await context.StoredEvents.AddAsync(storedEvent, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce domain event abstractions and aggregate root
- store emitted product events via EF-backed event store
- persist events after product creation command

## Testing
- `dotnet build` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0f7192d88328b4f8b1b6bc764a81